### PR TITLE
feat: use canonical QR decomposition in _make_orthonorm_weights

### DIFF
--- a/src/spectralnet/_models/_spectralnet_model.py
+++ b/src/spectralnet/_models/_spectralnet_model.py
@@ -45,6 +45,9 @@ class SpectralNetModel(nn.Module):
 
         m = Y.shape[0]
         _, R = torch.linalg.qr(Y)
+        # Canonical QR: flip row signs so diagonal of R is positive
+        signs = torch.sign(torch.diag(R))
+        R = signs.unsqueeze(1) * R
         orthonorm_weights = m**0.5 * torch.inverse(R)
         return orthonorm_weights
 


### PR DESCRIPTION
Multiply each row of R by the sign of its diagonal element to ensure R always has a positive diagonal, making the decomposition unique and preventing sign flips in orthonorm_weights across training iterations.